### PR TITLE
Add Apple silicon (MPS) and CPU support for eager inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ Breeze TTS 2 is an open-weight text-to-speech model built for real-time interact
 
 ### Requirements
 
-- Linux and Python 3.10 or newer
-- A CUDA-capable NVIDIA GPU
+- Python 3.10 or newer
+- Linux with a CUDA-capable NVIDIA GPU for the full feature set, including the fast path
 - GPU memory: approximately 7.7 GiB for eager inference or 14.4 GiB with `--fast-all`; use a 12 GB GPU for eager or a 24 GB GPU for the fast path
+- Apple silicon macOS runs eager inference on Metal (MPS); see [Apple silicon (MPS)](#apple-silicon-mps)
+- CPU-only hosts work as a slow fallback
 - The Breeze TTS 2 checkpoint
 
 ### Installation
@@ -60,6 +62,38 @@ python -m pip install -r requirements.txt
 ```
 
 All required model components are included in the Breeze TTS 2 checkpoint.
+
+### Apple silicon (MPS)
+
+Eager streaming runs on Apple silicon GPUs through Metal. The device is detected
+automatically, so the same commands work unchanged:
+
+```bash
+python infer.py ../breeze-tts-2 \
+  --text "It is good to hear your voice again after all this time." \
+  --output outputs/voice_clone_en.wav
+```
+
+Override the detected device or dtype with `--device` and `--dtype` (the CLI and
+the API both accept them; the `BREEZE_DEVICE` and `BREEZE_DTYPE` environment
+variables do the same):
+
+```bash
+python infer.py ../breeze-tts-2 --device mps --dtype float32 --text "Hello." --output outputs/out.wav
+```
+
+The default dtype is `bfloat16` on GPU and `float32` on CPU. Notes and limits:
+
+- The `--fast-*` flags are CUDA Graph based and are rejected on MPS and CPU; run
+  eager streaming instead.
+- `flash_attn` is CUDA-only, so the text encoder falls back to the eager
+  attention kernel automatically.
+- Expect a real-time factor around 2.5 for eager streaming on an M-series
+  laptop, roughly doubling when `--cfg-scale` is above 1, which runs a second
+  CFG branch.
+- Eager streaming needs no CPU fallback, but exporting
+  `PYTORCH_ENABLE_MPS_FALLBACK=1` is a safe net if a future op lacks a Metal
+  kernel.
 
 For the tested CUDA environment, build the included Docker image:
 

--- a/breeze_infer/api.py
+++ b/breeze_infer/api.py
@@ -18,6 +18,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from breeze_infer.runtime import (
     load_runtime,
     resolve_device,
+    resolve_dtype,
     set_all_seeds,
     update_generation_config_for_breeze,
 )
@@ -43,6 +44,8 @@ class ApiSettings:
     fast_backbone_decode: bool
     fast_depth_decoder: bool
     fast_codec: bool
+    device: str | None = None
+    dtype: str | None = None
 
 
 _settings: ApiSettings | None = None
@@ -73,10 +76,14 @@ async def _save_upload(upload: UploadFile) -> Path:
 
 
 def _load_app(app: FastAPI, settings: ApiSettings) -> None:
+    device = resolve_device(settings.device)
+    dtype = resolve_dtype(device, settings.dtype)
+    print(f"device: {device} dtype: {dtype}", flush=True)
     tokenizer, model, audio_tokenizer = load_runtime(
         settings.model,
-        device=resolve_device(),
+        device=device,
         attn_implementation="eager",
+        dtype=dtype,
     )
     update_generation_config_for_breeze(model)
 
@@ -234,6 +241,17 @@ def main() -> None:
     parser.add_argument(
         "--fast-codec", action=argparse.BooleanOptionalAction, default=False
     )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Torch device, e.g. cuda:0, mps, cpu (default: autodetect)",
+    )
+    parser.add_argument(
+        "--dtype",
+        default=None,
+        choices=["bfloat16", "float16", "float32"],
+        help="Model dtype (default: bfloat16 on GPU, float32 on CPU)",
+    )
     args = parser.parse_args()
 
     global _settings
@@ -245,6 +263,8 @@ def main() -> None:
         fast_backbone_decode=args.fast_backbone_decode,
         fast_depth_decoder=args.fast_depth_decoder,
         fast_codec=args.fast_codec,
+        device=args.device,
+        dtype=args.dtype,
     )
 
     import uvicorn

--- a/breeze_infer/runtime.py
+++ b/breeze_infer/runtime.py
@@ -19,14 +19,54 @@ def get_dist_info() -> tuple[int, int, int]:
     return rank, world_size, local_rank
 
 
+def mps_is_available() -> bool:
+    backend = getattr(torch.backends, "mps", None)
+    return bool(backend is not None and backend.is_available())
+
+
 def resolve_device(explicit_device: str | None = None) -> str:
     if explicit_device:
         return explicit_device
 
+    env_device = os.environ.get("BREEZE_DEVICE")
+    if env_device:
+        return env_device
+
     _, _, local_rank = get_dist_info()
     if torch.cuda.is_available():
         return f"cuda:{local_rank}"
+    if mps_is_available():
+        return "mps"
     return "cpu"
+
+
+_DTYPE_BY_NAME = {
+    "bfloat16": torch.bfloat16,
+    "bf16": torch.bfloat16,
+    "float16": torch.float16,
+    "fp16": torch.float16,
+    "half": torch.float16,
+    "float32": torch.float32,
+    "fp32": torch.float32,
+    "float": torch.float32,
+}
+
+
+def resolve_dtype(device: str, explicit_dtype: str | None = None) -> torch.dtype:
+    """Pick the model dtype for a device, honouring an explicit override."""
+    name = explicit_dtype or os.environ.get("BREEZE_DTYPE")
+    if name:
+        try:
+            return _DTYPE_BY_NAME[name.strip().lower()]
+        except KeyError:
+            raise ValueError(
+                f"unsupported dtype {name!r}; expected one of "
+                f"{sorted(set(_DTYPE_BY_NAME))}"
+            ) from None
+
+    if torch.device(device).type == "cpu":
+        return torch.float32
+    return torch.bfloat16
 
 
 def set_all_seeds(seed: int) -> None:
@@ -35,6 +75,8 @@ def set_all_seeds(seed: int) -> None:
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
+    if mps_is_available():
+        torch.mps.manual_seed(seed)
 
 
 def update_generation_config_for_breeze(
@@ -70,6 +112,7 @@ def load_runtime(
     *,
     device: str,
     attn_implementation: str,
+    dtype: torch.dtype | None = None,
 ) -> tuple[AutoTokenizer, BreezeForConditionalGeneration, Any]:
 
     if device.startswith("cuda"):
@@ -83,10 +126,12 @@ def load_runtime(
                 f"CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES')} "
                 f"device_count={torch.cuda.device_count()}"
             ) from exc
+    if dtype is None:
+        dtype = resolve_dtype(device)
     tokenizer = AutoTokenizer.from_pretrained(ckpt_dir)
     model = BreezeForConditionalGeneration.from_pretrained(
         ckpt_dir,
-        dtype=torch.bfloat16,
+        dtype=dtype,
         attn_implementation=attn_implementation,
     )
     model.to(device).eval()

--- a/infer.py
+++ b/infer.py
@@ -12,6 +12,7 @@ import soundfile as sf
 from breeze_infer.runtime import (
     load_runtime,
     resolve_device,
+    resolve_dtype,
     set_all_seeds,
     update_generation_config_for_breeze,
 )
@@ -37,6 +38,17 @@ def main() -> None:
     parser.add_argument("--output", type=Path, default=Path("output.wav"))
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--cfg-scale", type=float, default=DEFAULT_CFG_SCALE)
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Torch device, e.g. cuda:0, mps, cpu (default: autodetect)",
+    )
+    parser.add_argument(
+        "--dtype",
+        default=None,
+        choices=["bfloat16", "float16", "float32"],
+        help="Model dtype (default: bfloat16 on GPU, float32 on CPU)",
+    )
     parser.add_argument(
         "--fast-all", action=argparse.BooleanOptionalAction, default=None
     )
@@ -67,10 +79,14 @@ def main() -> None:
     if args.ref_audio is not None and not args.ref_audio.is_file():
         raise FileNotFoundError(f"Reference audio not found: {args.ref_audio}")
 
+    device = resolve_device(args.device)
+    dtype = resolve_dtype(device, args.dtype)
+    print(f"device: {device} dtype: {dtype}")
     tokenizer, model, audio_tokenizer = load_runtime(
         args.model,
-        device=resolve_device(),
+        device=device,
         attn_implementation="eager",
+        dtype=dtype,
     )
     update_generation_config_for_breeze(model)
 

--- a/models/breeze.py
+++ b/models/breeze.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from collections.abc import Callable
 
 from dataclasses import dataclass
@@ -50,6 +51,13 @@ from .breeze_config import BreezeConfig, BreezeDepthDecoderConfig
 from .generation_breeze import BreezeGenerationMixin
 
 logger = logging.get_logger(__name__)
+
+
+def _flash_attn_2_available() -> bool:
+    """flash_attn is a CUDA-only wheel; report whether it can actually be used."""
+    if not torch.cuda.is_available():
+        return False
+    return importlib.util.find_spec("flash_attn") is not None
 
 
 @dataclass
@@ -974,6 +982,18 @@ class BreezeForConditionalGeneration(BreezePreTrainedModel, BreezeGenerationMixi
             )
             if text_encoder_attn_implementation is None:
                 text_encoder_attn_implementation = "flash_attention_2"
+            if (
+                text_encoder_attn_implementation == "flash_attention_2"
+                and not _flash_attn_2_available()
+            ):
+                # flash_attn only ships for CUDA; fall back to the eager kernel
+                # so the text encoder still builds on MPS/CPU.
+                logger.warning(
+                    "flash_attn is unavailable; the text encoder falls back to "
+                    "the eager attention kernel. This is expected on MPS and CPU, "
+                    "but on CUDA it is slower than installing flash_attn."
+                )
+                text_encoder_attn_implementation = "eager"
             config.text_encoder_config._attn_implementation = (
                 text_encoder_attn_implementation
             )
@@ -984,7 +1004,7 @@ class BreezeForConditionalGeneration(BreezePreTrainedModel, BreezeGenerationMixi
                 self.text_encoder = AutoModel.from_config(
                     config.text_encoder_config,
                     attn_implementation=text_encoder_attn_implementation,
-                    dtype=torch.bfloat16,
+                    dtype=torch.get_default_dtype(),
                 )
 
             text_encoder_proj_type = getattr(config, "text_encoder_proj_type", "linear")

--- a/models/fast_streaming.py
+++ b/models/fast_streaming.py
@@ -147,6 +147,21 @@ def _left_pad_tensor(
     return torch.cat([pad, tensor], dim=1)
 
 
+def _sync_device(device: torch.device) -> None:
+    """Block until queued work on ``device`` finishes; a no-op on CPU."""
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    elif device.type == "mps":
+        torch.mps.synchronize()
+
+
+def _seed_device(device: torch.device, seed: int) -> None:
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(seed)
+    elif device.type == "mps":
+        torch.mps.manual_seed(seed)
+
+
 def _extract_audio_np(audio: torch.Tensor) -> np.ndarray:
     while audio.dim() > 1:
         audio = audio[0]
@@ -189,8 +204,12 @@ class FastBreezeStreamingRuntime:
             range(self._codec_codebook_size, int(self.model.config.vocab_size))
         )
 
-        if self.device.type != "cuda":
-            raise RuntimeError("fast streaming requires a CUDA device")
+        if self.fast_enabled and self.device.type != "cuda":
+            raise RuntimeError(
+                "fast streaming stages require a CUDA device; "
+                f"got {self.device.type}. Run without --fast-* flags for "
+                "eager streaming on this device."
+            )
         if self.config.repetition_penalty <= 0:
             raise ValueError("repetition_penalty must be > 0")
 
@@ -529,7 +548,7 @@ class FastBreezeStreamingRuntime:
                 depth_bucket_sizes=list(profile.depth_decoder_batch_sizes),
             )
         assert self._depth_decoder_graph is not None
-        torch.cuda.synchronize(self.device)
+        _sync_device(self.device)
         graph_elapsed_ms = (time.perf_counter() - graph_started) * 1000.0
         stages["backbone_decode"] = {
             "fast": self._fast_backbone_decode,
@@ -562,7 +581,7 @@ class FastBreezeStreamingRuntime:
                 suppress_tokens=self._reserved_codec_token_ids,
                 **backbone_params,
             )
-        torch.cuda.synchronize(self.device)
+        _sync_device(self.device)
         stages["backbone_decode"]["sampling_warmup_ms"] = (
             time.perf_counter() - sampling_started
         ) * 1000.0
@@ -587,7 +606,7 @@ class FastBreezeStreamingRuntime:
             text_graph_keys = text_cache.graph_keys
             if profile.freeze_after_warmup:
                 text_cache.freeze()
-        torch.cuda.synchronize(self.device)
+        _sync_device(self.device)
         stages["text_encoder"] = {
             "fast": self._fast_text_encoder,
             "graphs": [
@@ -619,7 +638,7 @@ class FastBreezeStreamingRuntime:
                 self._backbone_prefill_graph = self._backbone_prefill_graphs.get(
                     self._backbone_graph.batch_size
                 )
-        torch.cuda.synchronize(self.device)
+        _sync_device(self.device)
         stages["backbone_prefill"] = {
             "fast": self._fast_backbone_prefill,
             "graphs": [
@@ -647,7 +666,7 @@ class FastBreezeStreamingRuntime:
         )
         _extract_audio_np(codec_audio)
         codec.close_request(codec_request_id)
-        torch.cuda.synchronize(self.device)
+        _sync_device(self.device)
         stages["codec"] = {
             "fast": self._fast_codec,
             "graphs": [
@@ -676,7 +695,7 @@ class FastBreezeStreamingRuntime:
             synthetic_started = time.perf_counter()
             request_id = f"profile-first-frame-cfg{cfg_scale:g}"
             torch.manual_seed(request_spec.seed)
-            torch.cuda.manual_seed_all(request_spec.seed)
+            _seed_device(self.device, request_spec.seed)
             synthetic_inputs = prepare_inputs(
                 self.tokenizer,
                 self.audio_tokenizer,
@@ -706,7 +725,7 @@ class FastBreezeStreamingRuntime:
                     ) from exc
             finally:
                 synthetic_iterator.close()
-            torch.cuda.synchronize(self.device)
+            _sync_device(self.device)
             synthetic_results.append(
                 {
                     "template": request_spec.template,
@@ -771,7 +790,7 @@ class FastBreezeStreamingRuntime:
         t_chunk = t_start
         prefill_start_event = None
         prefill_end_event = None
-        if self.config.collect_timing:
+        if self.config.collect_timing and self.device.type == "cuda":
             prefill_start_event = torch.cuda.Event(enable_timing=True)
             prefill_end_event = torch.cuda.Event(enable_timing=True)
             prefill_start_event.record()

--- a/tests/test_device_resolution.py
+++ b/tests/test_device_resolution.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+from breeze_infer.runtime import resolve_device, resolve_dtype
+
+
+def test_explicit_device_wins_over_env(monkeypatch):
+    monkeypatch.setenv("BREEZE_DEVICE", "cpu")
+    assert resolve_device("mps") == "mps"
+
+
+def test_env_device_is_used_when_no_explicit_device(monkeypatch):
+    monkeypatch.setenv("BREEZE_DEVICE", "mps")
+    assert resolve_device() == "mps"
+
+
+def test_mps_is_preferred_over_cpu(monkeypatch):
+    monkeypatch.delenv("BREEZE_DEVICE", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr("breeze_infer.runtime.mps_is_available", lambda: True)
+    assert resolve_device() == "mps"
+
+
+def test_cuda_is_preferred_over_mps(monkeypatch):
+    monkeypatch.delenv("BREEZE_DEVICE", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr("breeze_infer.runtime.mps_is_available", lambda: True)
+    assert resolve_device() == "cuda:0"
+
+
+def test_cpu_falls_back_when_no_accelerator(monkeypatch):
+    monkeypatch.delenv("BREEZE_DEVICE", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr("breeze_infer.runtime.mps_is_available", lambda: False)
+    assert resolve_device() == "cpu"
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [("cuda:0", torch.bfloat16), ("mps", torch.bfloat16), ("cpu", torch.float32)],
+)
+def test_default_dtype_per_device(monkeypatch, device, expected):
+    monkeypatch.delenv("BREEZE_DTYPE", raising=False)
+    assert resolve_dtype(device) == expected
+
+
+def test_explicit_dtype_overrides_device_default(monkeypatch):
+    monkeypatch.delenv("BREEZE_DTYPE", raising=False)
+    assert resolve_dtype("mps", "float32") is torch.float32
+    assert resolve_dtype("cpu", "bfloat16") is torch.bfloat16
+
+
+def test_env_dtype_is_used(monkeypatch):
+    monkeypatch.setenv("BREEZE_DTYPE", "float16")
+    assert resolve_dtype("mps") is torch.float16
+
+
+def test_unknown_dtype_raises(monkeypatch):
+    monkeypatch.delenv("BREEZE_DTYPE", raising=False)
+    with pytest.raises(ValueError, match="unsupported dtype"):
+        resolve_dtype("mps", "float8")

--- a/tests/test_fast_streaming.py
+++ b/tests/test_fast_streaming.py
@@ -159,3 +159,25 @@ def test_single_cfg_merges_cond_and_uncond_in_one_batched_text_path() -> None:
 
     assert eager_branch.branch_batch_size == 2
     assert len(runtime.model.calls) == 2
+
+
+def test_fast_streaming_rejects_fast_stages_off_cuda():
+    """Fast stages need CUDA Graphs; eager streaming must still build elsewhere."""
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(1))
+            self.config = SimpleNamespace(
+                codec_config=SimpleNamespace(codebook_size=8, sampling_rate=24000),
+                vocab_size=16,
+            )
+
+    model = _Model()
+    with pytest.raises(RuntimeError, match="fast streaming stages require a CUDA"):
+        FastBreezeStreamingRuntime(
+            model, None, FastStreamingConfig(fast_all=True)
+        )
+
+    runtime = FastBreezeStreamingRuntime(model, None, FastStreamingConfig())
+    assert not runtime.fast_enabled
+    assert runtime.device.type == "cpu"


### PR DESCRIPTION
## Summary

Eager streaming is already device-agnostic, but three hard CUDA assumptions stop it from starting anywhere else. This makes the eager path run on Apple silicon GPUs via Metal (MPS) and on plain CPU. The CUDA fast path is untouched.

## What was blocking non-CUDA hosts

1. **`resolve_device()` only knew CUDA** — fell through to `cpu` on a Mac with a working Metal GPU.
2. **The text encoder hardcoded `attn_implementation="flash_attention_2"`** ([`models/breeze.py`](https://github.com/breezeblue-ai/breeze-tts/blob/main/models/breeze.py)). `flash_attn` is a CUDA-only wheel, so simply *constructing* the model raised `ImportError` on any other host. Worth noting the bundled `t5gemma2_flash_attention_forward` already routes non-CUDA tensors to the eager kernel — so this only ever failed at the transformers dispatch check, never for a real numerical reason.
3. **`FastBreezeStreamingRuntime.__init__` raised `"fast streaming requires a CUDA device"`** unconditionally, which rejected eager streaming along with the fast stages.

Also fixed: the text encoder was pinned to `bfloat16` regardless of the dtype passed to `from_pretrained`.

## Changes

- `resolve_device()` detects MPS after CUDA; honours `BREEZE_DEVICE`.
- New `resolve_dtype()` with `--dtype` / `BREEZE_DTYPE`; defaults to `bfloat16` on GPU, `float32` on CPU. The text encoder now follows the model dtype.
- The flash-attention fallback to `eager` is automatic, with a `logger.warning` so the CUDA-without-flash_attn case stays visible rather than silently losing performance.
- The CUDA requirement now applies only when a fast stage is actually enabled, and the error says how to proceed.
- Guarded the CUDA-only calls on shared code paths: `synchronize`, seeding, timing `Event`s.
- `--device` and `--dtype` flags on both the CLI and the streaming API.
- 10 new tests covering device/dtype resolution and the fast-stage guard.

## Verification

On an M4 Max MacBook Pro (macOS 26.5, torch 2.9.1) against the `breeze-tts-2` checkpoint — voice clone, voice design, voice direction (`--cfg-scale 4`, exercising the batch=2 CFG branch), the streaming API, `float32`, and the CPU fallback all produce audio.

- Eager streaming needs **no** `PYTORCH_ENABLE_MPS_FALLBACK`; every op has a Metal kernel.
- Real-time factor ≈ 2.4–2.9 on that machine, roughly doubling with `--cfg-scale` above 1.
- Model load ≈ 4 s.
- `--fast-*` on MPS/CPU is rejected with a clear, actionable error.
- `pytest`: 40 passed. `ruff` clean on all touched files (the 5 pre-existing findings in `models/breeze.py` are unchanged in count and kind).

## Not addressed

The `--fast-*` stages are built on CUDA Graphs and have no Metal equivalent; they stay CUDA-only by design.
