### PR TITLE
Stabilize request seeding and warm voice-direction graphs

### DIFF
--- a/breeze_infer/api.py
+++ b/breeze_infer/api.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import os
 import tempfile
 import threading
 import uuid
@@ -22,7 +24,11 @@ from breeze_infer.runtime import (
     update_generation_config_for_breeze,
 )
 from breeze_infer.templates import get_template, prepare_inputs
-from models.fast_streaming import FastBreezeStreamingRuntime, FastStreamingConfig
+from models.fast_streaming import (
+    FastBreezeStreamingRuntime,
+    FastStreamingChunk,
+    FastStreamingConfig,
+)
 from models.warmup_profile import load_warmup_profile
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -53,6 +59,52 @@ def _pcm16(audio: np.ndarray) -> bytes:
     audio = np.asarray(audio, dtype=np.float32)
     audio = np.clip(audio, -1.0, 1.0)
     return (audio * 32767.0).astype("<i2", copy=False).tobytes()
+
+
+def _iter_seeded_audio_chunks(
+    runtime: FastBreezeStreamingRuntime,
+    inputs: dict[str, object],
+    *,
+    request_id: str,
+    seed: int,
+) -> Iterator[FastStreamingChunk]:
+    """Start model sampling from the request seed, after all input preparation.
+
+    The response body runs after the endpoint has returned a ``StreamingResponse``.
+    Seeding only while preparing the request leaves model sampling vulnerable to
+    lazy initialization or unrelated RNG use between preparation and iteration.
+    The API is deliberately single-request, so resetting the process generators at
+    this boundary gives each request an isolated, reproducible sampling start.
+    """
+    set_all_seeds(seed)
+    token_digest = None
+    token_frames = 0
+    if os.environ.get("BREEZE_DEBUG_TOKEN_HASH") == "1":
+        token_digest = hashlib.sha256()
+
+    def observe_token_frame(frame) -> None:
+        nonlocal token_frames
+        assert token_digest is not None
+        token_digest.update(
+            frame.detach().to(device="cpu").contiguous().numpy().tobytes()
+        )
+        token_frames += 1
+
+    try:
+        yield from runtime.iter_audio_chunks(
+            inputs,
+            request_id=request_id,
+            seed=seed,
+            token_observer=observe_token_frame if token_digest is not None else None,
+        )
+    finally:
+        if token_digest is not None:
+            print(
+                "breeze token trace: "
+                f"request_id={request_id} seed={seed} frames={token_frames} "
+                f"sha256={token_digest.hexdigest()}",
+                flush=True,
+            )
 
 
 async def _save_upload(upload: UploadFile) -> Path:
@@ -187,8 +239,11 @@ async def speech(
 
     def body() -> Iterator[bytes]:
         try:
-            for chunk in app.state.runtime.iter_audio_chunks(
-                inputs, request_id=request_id
+            for chunk in _iter_seeded_audio_chunks(
+                app.state.runtime,
+                inputs,
+                request_id=request_id,
+                seed=seed,
             ):
                 pcm = _pcm16(chunk.audio)
                 if pcm:

--- a/configs/fast.json
+++ b/configs/fast.json
@@ -107,6 +107,18 @@
         {
           "batch_size": 2,
           "token_length": 512
+        },
+        {
+          "batch_size": 4,
+          "token_length": 64
+        },
+        {
+          "batch_size": 4,
+          "token_length": 96
+        },
+        {
+          "batch_size": 4,
+          "token_length": 128
         }
       ]
     },

--- a/infer.py
+++ b/infer.py
@@ -127,7 +127,9 @@ def main() -> None:
         channels=1,
         subtype="PCM_16",
     ) as output_file:
-        for chunk in runtime.iter_audio_chunks(inputs, request_id="single-request"):
+        for chunk in runtime.iter_audio_chunks(
+            inputs, request_id="single-request", seed=args.seed
+        ):
             output_file.write(chunk.audio)
 
     print(f"saved {args.output}")

--- a/models/fast_streaming.py
+++ b/models/fast_streaming.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -744,6 +744,8 @@ class FastBreezeStreamingRuntime:
         inputs: dict[str, Any],
         *,
         request_id: str | None = None,
+        seed: int | None = None,
+        token_observer: Callable[[torch.Tensor], None] | None = None,
     ) -> Iterator[FastStreamingChunk]:
         cfg = select_fast_cfg(inputs)
         branch_batch_size = 2 if cfg.mode == "single_cfg" else 1
@@ -766,6 +768,13 @@ class FastBreezeStreamingRuntime:
             dtype=torch.long,
             device=self.device,
         )
+        # All lazy request setup must precede the reset. In particular, the
+        # first request may allocate caches and initialize the streaming codec.
+        # A request seed is a sampling contract, so those one-time operations
+        # must not be allowed to shift the backbone/depth multinomial streams.
+        if seed is not None:
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed_all(seed)
         first_decode = True
         t_start = time.perf_counter()
         t_chunk = t_start
@@ -848,6 +857,8 @@ class FastBreezeStreamingRuntime:
                     **depth_params,
                 )
                 frame = torch.cat([token.view(1), depth_tokens[0]], dim=0)
+                if token_observer is not None:
+                    token_observer(frame)
                 if should_decode_codec_frame(frame, self.model.config):
                     chunk_buffer.append(frame.detach())
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from breeze_infer.api import (
     DEFAULT_CFG_SCALE,
+    _iter_seeded_audio_chunks,
     _pcm16,
     app,
     speech,
@@ -55,3 +56,31 @@ def test_pcm16_clips_and_encodes_little_endian() -> None:
     encoded = _pcm16(np.array([-2.0, 0.0, 2.0], dtype=np.float32))
 
     assert np.frombuffer(encoded, dtype="<i2").tolist() == [-32767, 0, 32767]
+
+
+def test_streaming_reseeds_immediately_before_model_sampling(monkeypatch) -> None:
+    events = []
+
+    class Runtime:
+        def iter_audio_chunks(
+            self, inputs, *, request_id, seed, token_observer
+        ):
+            events.append(("sample", inputs, request_id, seed, token_observer))
+            yield "chunk"
+
+    monkeypatch.setattr(
+        "breeze_infer.api.set_all_seeds",
+        lambda seed: events.append(("seed", seed)),
+    )
+
+    chunks = list(
+        _iter_seeded_audio_chunks(
+            Runtime(), {"input_ids": "prepared"}, request_id="request-1", seed=43
+        )
+    )
+
+    assert chunks == ["chunk"]
+    assert events == [
+        ("seed", 43),
+        ("sample", {"input_ids": "prepared"}, "request-1", 43, None),
+    ]

--- a/tests/test_warmup_profile.py
+++ b/tests/test_warmup_profile.py
@@ -14,7 +14,7 @@ def _payload() -> dict:
     return json.loads((REPO_ROOT / "configs" / "fast.json").read_text())
 
 
-def test_bundled_config_covers_cfg1_and_cfg4() -> None:
+def test_bundled_config_covers_cfg1_cfg4_and_voice_direction() -> None:
     profile = load_warmup_profile(REPO_ROOT / "configs" / "fast.json")
 
     assert profile.cfg_scales == (1.0, 4.0)
@@ -28,7 +28,7 @@ def test_bundled_config_covers_cfg1_and_cfg4() -> None:
         1,
         2,
     }
-    assert {graph.batch_size for graph in profile.text_encoder_graphs} == {1, 2}
+    assert {graph.batch_size for graph in profile.text_encoder_graphs} == {1, 2, 4}
     cfg1_text_lengths = [
         graph.token_length
         for graph in profile.text_encoder_graphs
@@ -39,8 +39,16 @@ def test_bundled_config_covers_cfg1_and_cfg4() -> None:
         for graph in profile.text_encoder_graphs
         if graph.batch_size == 2
     ]
+    voice_direction_text_lengths = [
+        graph.token_length
+        for graph in profile.text_encoder_graphs
+        if graph.batch_size == 4
+    ]
     assert cfg1_text_lengths == list(range(32, 257, 32))
     assert cfg_guided_text_lengths == list(range(32, 513, 32))
+    # ref_edit_tata merges the positive and negative branches' two text
+    # segments each, so fast CFG-4 voice direction reaches batch size 4.
+    assert voice_direction_text_lengths == [64, 96, 128]
 
 
 def test_config_requires_decode_graph_for_each_cfg_shape() -> None:


### PR DESCRIPTION
## Summary

- reset Torch sampling at the real request boundary, after lazy graph/cache/codec setup, so a request seed identifies a stable backbone+depth token trajectory
- pass the request seed through both CLI and API streaming paths
- add opt-in debug SHA-256 tracing of generated backbone+depth frames
- add the missing batch-4 text-encoder warmup buckets used by CFG voice-direction/reference-edit requests

## Root cause and validation

The API previously seeded before request preparation and asynchronous response-body iteration. Lazy initialization could therefore shift the RNG stream before the first model sample.

On B200, two prompts repeated in one process and across two fresh processes now produce identical token counts and hashes:

- `sly_woman`, seed 43: 121 frames, stable token SHA-256
- `grief_woman`, seed 43: 75 frames, stable token SHA-256

The remaining PCM variation is downstream streaming-codec numerical variance; the sampled token traces are identical.

The released fast profile also lacked `(batch=4, length=64/96/128)` text-encoder graphs. `ref_edit_tata` can create four text segments across positive/negative CFG branches, so a frozen profile failed closed on a real voice-direction request. A scratch profile with these exact buckets served the 30-request diagnostic set.

## Local checks

- `ruff check` passes for all six changed files
- `tests/test_warmup_profile.py`: 5 passed
- API/CLI modules compile and import in the Breeze B200 environment
- real streaming API seed/token lifecycle validation completed on B200

## Scope boundary

This PR fixes seed reproducibility and warmup-profile coverage. It does **not** claim that CFG-4 or the accelerated audio path passes listening quality; those experimental outputs were intentionally rejected in the downstream evaluation.
