### PR TITLE
Fix nested attention selection and repeated runtime cache dtype

### DIFF
--- a/models/breeze.py
+++ b/models/breeze.py
@@ -52,6 +52,20 @@ from .generation_breeze import BreezeGenerationMixin
 logger = logging.get_logger(__name__)
 
 
+def _resolve_text_encoder_attn_implementation(config) -> str:
+    """Honor an explicit top-level attention choice before checkpoint preference."""
+    caller_attn_implementation = getattr(config, "_attn_implementation", None)
+    if caller_attn_implementation is not None:
+        return caller_attn_implementation
+
+    preferred_attn_implementation = getattr(
+        config.text_encoder_config,
+        "preferred_attn_implementation",
+        None,
+    )
+    return preferred_attn_implementation or "flash_attention_2"
+
+
 @dataclass
 @auto_docstring(
     custom_intro="""
@@ -967,13 +981,9 @@ class BreezeForConditionalGeneration(BreezePreTrainedModel, BreezeGenerationMixi
                     f"  - [BreezeForConditionalGeneration] Text encoder feature layer idx: {self.text_encoder_feature_layer_idx}"
                 )
 
-            text_encoder_attn_implementation = getattr(
-                config.text_encoder_config,
-                "preferred_attn_implementation",
-                None,
+            text_encoder_attn_implementation = (
+                _resolve_text_encoder_attn_implementation(config)
             )
-            if text_encoder_attn_implementation is None:
-                text_encoder_attn_implementation = "flash_attention_2"
             config.text_encoder_config._attn_implementation = (
                 text_encoder_attn_implementation
             )

--- a/models/fast_streaming.py
+++ b/models/fast_streaming.py
@@ -130,6 +130,16 @@ def _get_device(model: torch.nn.Module) -> torch.device:
 
 
 def _get_dtype(model: torch.nn.Module) -> torch.dtype:
+    # The composite model registers lm_head before the semantic backbone. CUDA
+    # graph setup intentionally casts that shared projection head to float32,
+    # so using the first composite parameter makes a later runtime select an
+    # FP32 KV cache for an otherwise BF16 backbone.
+    backbone_model = getattr(model, "backbone_model", None)
+    if isinstance(backbone_model, torch.nn.Module):
+        try:
+            return next(backbone_model.parameters()).dtype
+        except StopIteration:
+            pass
     try:
         return next(model.parameters()).dtype
     except StopIteration:

--- a/tests/test_attention_config.py
+++ b/tests/test_attention_config.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from models.breeze import _resolve_text_encoder_attn_implementation
+
+
+def _config(*, caller=None, preferred=None):
+    return SimpleNamespace(
+        _attn_implementation=caller,
+        text_encoder_config=SimpleNamespace(
+            preferred_attn_implementation=preferred
+        ),
+    )
+
+
+def test_explicit_attention_choice_overrides_checkpoint_preference() -> None:
+    config = _config(caller="eager", preferred="flash_attention_2")
+
+    assert _resolve_text_encoder_attn_implementation(config) == "eager"
+
+
+def test_checkpoint_attention_preference_is_used_without_explicit_choice() -> None:
+    config = _config(caller=None, preferred="sdpa")
+
+    assert _resolve_text_encoder_attn_implementation(config) == "sdpa"
+
+
+def test_text_encoder_attention_keeps_legacy_default() -> None:
+    config = _config(caller=None, preferred=None)
+
+    assert _resolve_text_encoder_attn_implementation(config) == "flash_attention_2"

--- a/tests/test_fast_streaming.py
+++ b/tests/test_fast_streaming.py
@@ -9,12 +9,32 @@ from breeze_infer.templates import get_template
 from models.fast_streaming import (
     FastBreezeStreamingRuntime,
     FastStreamingConfig,
+    _get_dtype,
     is_backbone_eos_token,
     is_terminal_pad_frame,
     reject_dual_cfg,
     select_fast_cfg,
     should_decode_codec_frame,
 )
+
+
+def test_runtime_dtype_follows_backbone_after_shared_lm_head_is_cast() -> None:
+    class CompositeModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lm_head = torch.nn.Linear(2, 2, bias=False, dtype=torch.bfloat16)
+            self.backbone_model = torch.nn.Linear(
+                2, 2, bias=False, dtype=torch.bfloat16
+            )
+
+    model = CompositeModel()
+    assert _get_dtype(model) == torch.bfloat16
+
+    # BackboneGraph mutates the shared projection in exactly this way.
+    model.lm_head.float()
+
+    assert next(model.parameters()).dtype == torch.float32
+    assert _get_dtype(model) == torch.bfloat16
 
 
 def test_fast_streaming_defaults_to_repetition_penalty_1p1() -> None:


### PR DESCRIPTION
## Summary

- Honor the explicit top-level attention implementation when constructing the nested text encoder, while retaining the checkpoint preference as a fallback.
- Derive the streaming KV-cache dtype from the semantic backbone instead of the shared `lm_head`, which graph setup may convert to FP32.
- Add regression tests for attention selection and repeated streaming runtime initialization.

Fixes #7
Fixes #8

## Validation

- `python -m pytest -q tests`: 32 passed.
- H100 with the real checkpoint: before the dtype fix, the second runtime failed with a Float/BFloat16 `index_copy_` mismatch; after the fix, both runtimes generated 3840 samples and the second runtime remained BF16.
- NVIDIA Ampere SM86 GPU (24 GB), PyTorch 2.9.1+cu128, CUDA 12.8, without `flash-attn`: explicit eager attention reached the nested text encoder; two consecutive runtimes both remained BF16 and generated 3840 samples.
- Ruff passed on the changed code, excluding five pre-existing findings in `models/breeze.py`.
