### PR TITLE
Expand voice-direction CUDA Graph coverage

### DIFF
--- a/configs/fast.json
+++ b/configs/fast.json
@@ -110,6 +110,10 @@
         },
         {
           "batch_size": 4,
+          "token_length": 32
+        },
+        {
+          "batch_size": 4,
           "token_length": 64
         },
         {
@@ -119,6 +123,14 @@
         {
           "batch_size": 4,
           "token_length": 128
+        },
+        {
+          "batch_size": 4,
+          "token_length": 160
+        },
+        {
+          "batch_size": 4,
+          "token_length": 256
         }
       ]
     },

--- a/models/text_encoder_graph.py
+++ b/models/text_encoder_graph.py
@@ -45,6 +45,20 @@ class TextEncoderGraphCache:
         ) * self.token_granularity
 
     @staticmethod
+    def _smallest_fitting_key(
+        keys: Sequence[tuple[int, int]],
+        *,
+        batch_size: int,
+        token_length: int,
+    ) -> tuple[int, int] | None:
+        candidates = [
+            key
+            for key in keys
+            if key[0] == batch_size and key[1] >= token_length
+        ]
+        return min(candidates, key=lambda key: key[1], default=None)
+
+    @staticmethod
     def _copy_inputs(
         segments: Sequence[torch.Tensor],
         input_ids: torch.Tensor,
@@ -73,15 +87,22 @@ class TextEncoderGraphCache:
             raise ValueError("text encoder graph does not support empty segments")
         batch_size = len(segments)
         max_length = self._bucket(max(lengths))
-        key = (batch_size, max_length)
+        requested_key = (batch_size, max_length)
 
         with self._lock:
-            record = self._records.get(key)
+            key = self._smallest_fitting_key(
+                self._records,
+                batch_size=batch_size,
+                token_length=max_length,
+            )
+            record = self._records.get(key) if key is not None else None
             if record is None:
                 if self._frozen:
                     raise RuntimeError(
-                        f"text encoder CUDA graph {key} was not declared in the warmup profile"
+                        f"text encoder CUDA graph {requested_key} has no fitting bucket "
+                        "in the warmup profile"
                     )
+                key = requested_key
                 device = segments[0].device
                 static_ids = torch.zeros(
                     (batch_size, max_length), dtype=segments[0].dtype, device=device

--- a/tests/test_text_encoder_graph.py
+++ b/tests/test_text_encoder_graph.py
@@ -1,0 +1,20 @@
+from models.text_encoder_graph import TextEncoderGraphCache
+
+
+def test_smallest_fitting_key_reuses_larger_token_bucket() -> None:
+    keys = ((4, 32), (4, 64), (4, 96), (4, 128), (4, 160), (4, 256))
+
+    assert TextEncoderGraphCache._smallest_fitting_key(
+        keys, batch_size=4, token_length=192
+    ) == (4, 256)
+
+
+def test_smallest_fitting_key_does_not_cross_batch_sizes() -> None:
+    keys = ((1, 256), (2, 256), (4, 160))
+
+    assert (
+        TextEncoderGraphCache._smallest_fitting_key(
+            keys, batch_size=4, token_length=192
+        )
+        is None
+    )

--- a/tests/test_warmup_profile.py
+++ b/tests/test_warmup_profile.py
@@ -48,7 +48,7 @@ def test_bundled_config_covers_cfg1_cfg4_and_voice_direction() -> None:
     assert cfg_guided_text_lengths == list(range(32, 513, 32))
     # ref_edit_tata merges the positive and negative branches' two text
     # segments each, so fast CFG-4 voice direction reaches batch size 4.
-    assert voice_direction_text_lengths == [64, 96, 128]
+    assert voice_direction_text_lengths == [32, 64, 96, 128, 160, 256]
 
 
 def test_config_requires_decode_graph_for_each_cfg_shape() -> None:


### PR DESCRIPTION
## Summary

- select the smallest prewarmed text-encoder graph that fits the requested token length
- add batch-4 buckets for 32, 160, and 256 tokens
- add regression coverage for sparse bucket reuse and batch isolation

## Validation

- `pytest -q -p no:cacheprovider`: 35 passed
- PyTorch 2.9.1+cu128, Transformers 4.57.3, NVIDIA H100
- full CUDA Graph warmup completed
- a `(4, 192)` replay selected `(4, 256)` and returned four `(192, 1152)` outputs
- an end-to-end `ref_edit_tata`, CFG=4 request with text segment lengths `[9, 254, 9, 237]` generated the first 1,920-sample audio chunk successfully

The three additional graph captures add about 146 MiB of reserved CUDA memory relative to the current main profile.