### PR TITLE
fix: disable inapplicable tokenizer regex patch

### DIFF
--- a/breeze_infer/runtime.py
+++ b/breeze_infer/runtime.py
@@ -83,7 +83,10 @@ def load_runtime(
                 f"CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES')} "
                 f"device_count={torch.cuda.device_count()}"
             ) from exc
-    tokenizer = AutoTokenizer.from_pretrained(ckpt_dir)
+    tokenizer = AutoTokenizer.from_pretrained(
+        ckpt_dir,
+        fix_mistral_regex=False,
+    )
     model = BreezeForConditionalGeneration.from_pretrained(
         ckpt_dir,
         dtype=torch.bfloat16,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from breeze_infer.runtime import load_runtime
+
+
+def test_load_runtime_disables_inapplicable_mistral_regex_fix(tmp_path) -> None:
+    (tmp_path / "audio_tokenizer").mkdir()
+    model = MagicMock()
+    audio_tokenizer = object()
+    qwen_tts = SimpleNamespace(
+        Qwen3TTSTokenizer=SimpleNamespace(
+            from_pretrained=MagicMock(return_value=audio_tokenizer)
+        )
+    )
+
+    with (
+        patch(
+            "breeze_infer.runtime.AutoTokenizer.from_pretrained",
+            return_value=object(),
+        ) as load_tokenizer,
+        patch(
+            "breeze_infer.runtime.BreezeForConditionalGeneration.from_pretrained",
+            return_value=model,
+        ),
+        patch.dict(sys.modules, {"qwen_tts": qwen_tts}),
+    ):
+        load_runtime(tmp_path, device="cpu", attn_implementation="eager")
+
+    load_tokenizer.assert_called_once_with(
+        tmp_path,
+        fix_mistral_regex=False,
+    )


### PR DESCRIPTION
Summary
Fixes the tokenizer regex warning when loading Breeze-TTS-2 with Transformers 4.57.3.
Breeze-TTS-2 uses GemmaTokenizerFast, so the automatic Mistral regex fix is not applicable and can cause a TypeError when enabled. This PR explicitly sets fix_mistral_regex=False.
Validation
- Confirmed the tokenizer loads without the warning.
- Verified token IDs remain unchanged.
- Added a regression test for the runtime loading configuration.
